### PR TITLE
Fix for Issue 88

### DIFF
--- a/modules/redhen_contact/src/Form/ContactSettingsForm.php
+++ b/modules/redhen_contact/src/Form/ContactSettingsForm.php
@@ -149,8 +149,8 @@ class ContactSettingsForm extends ConfigFormBase {
             '#description' => t('Select the allowed contact types to create during registration. This can be overridden by appending the contact type machine name in the registration url.'),
             '#default_value' => $config->get('registration_type'),
             '#states' => array(
-              'invisible' => array(
-                ':input[name="registration"]' => array('checked' => FALSE),
+              'visible' => array(
+                ':input[name="registration"]' => array('checked' => TRUE),
               ),
             ),
           ),

--- a/modules/redhen_contact/src/Form/ContactSettingsForm.php
+++ b/modules/redhen_contact/src/Form/ContactSettingsForm.php
@@ -91,9 +91,6 @@ class ContactSettingsForm extends ConfigFormBase {
           'enabled' => array(
             ':input[name="valid_email"]' => array('checked' => TRUE),
           ),
-          'unchecked' => array(
-            ':input[name="valid_email"]' => array('checked' => FALSE),
-          ),
         ),
       ),
       'embed_on_user_form' => array(
@@ -104,9 +101,6 @@ class ContactSettingsForm extends ConfigFormBase {
         '#states' => array(
           'enabled' => array(
             ':input[name="connect_users"]' => array('checked' => TRUE),
-          ),
-          'unchecked' => array(
-            ':input[name="connect_users"]' => array('checked' => FALSE),
           ),
         ),
       ),

--- a/modules/redhen_contact/src/Form/ContactSettingsForm.php
+++ b/modules/redhen_contact/src/Form/ContactSettingsForm.php
@@ -167,11 +167,6 @@ class ContactSettingsForm extends ConfigFormBase {
             '#title' => t('Update contact fields'),
             '#description' => t('When an existing contact is found and linked to, the submitted field values will overwrite the existing contact field values.'),
             '#default_value' => $config->get('registration_update'),
-            '#states' => array(
-              'invisible' => array(
-                ':input[name="contact_reg_link"]' => array('checked' => FALSE),
-              ),
-            ),
           ),
         ),
       ),

--- a/modules/redhen_contact/src/Form/ContactSettingsForm.php
+++ b/modules/redhen_contact/src/Form/ContactSettingsForm.php
@@ -45,12 +45,23 @@ class ContactSettingsForm extends ConfigFormBase {
    *   The current state of the form.
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Must require a valid email to connect Contacts and Drupal Users.
+    $connect_users = $form_state->getValue('valid_email') && $form_state->getValue('connect_users');
+
+    // Contacts must be connected to Users if we're going to embed the Contact
+    // fields on the User form.
+    $embed_on_user_form = $form_state->getValue('connect_users') && $form_state->getValue('embed_on_user_form');
+
+    // Require unique email if we're connecting Contacts to Users.
+    $unique_email = $connect_users || $form_state->getValue('unique_email');
+
     \Drupal::service('config.factory')
       ->getEditable('redhen_contact.settings')
       ->set('valid_email', $form_state->getValue('valid_email'))
-      ->set('connect_users', $form_state->getValue('connect_users'))
-      ->set('embed_on_user_form', $form_state->getValue('embed_on_user_form'))
-      ->set('unique_email', $form_state->getValue('unique_email'))
+      ->set('connect_users', $connect_users)
+      ->set('embed_on_user_form', $embed_on_user_form)
+      ->set('unique_email', $unique_email)
       ->set('alter_username', $form_state->getValue('alter_username'))
       ->set('registration', $form_state->getValue('registration'))
       ->set('registration_type', $form_state->getValue('registration_type'))
@@ -88,7 +99,7 @@ class ContactSettingsForm extends ConfigFormBase {
         '#description' => t('If checked, RedHen will attempt to connect Drupal users to RedHen contacts by matching email addresses when a contact is updated.'),
         '#default_value' => $config->get('connect_users'),
         '#states' => array(
-          'enabled' => array(
+          'visible' => array(
             ':input[name="valid_email"]' => array('checked' => TRUE),
           ),
         ),
@@ -99,7 +110,7 @@ class ContactSettingsForm extends ConfigFormBase {
         '#description' => t('If checked, the RedHen Contact tab on users will be removed, and the Contact edit fields will instead be attached to the bottom of the User Edit form.'),
         '#default_value' => $config->get('embed_on_user_form'),
         '#states' => array(
-          'enabled' => array(
+          'visible' => array(
             ':input[name="connect_users"]' => array('checked' => TRUE),
           ),
         ),


### PR DESCRIPTION
Change approach for disabling dependent fields on Contact settings form.

Previously we were disabling two fields if their dependent checkbox wasn’t checked, but that makes for bad UX if the child field is checked, then the parent field gets unchecked, and the end-user sees the child field checked and disabled.

This PR hides the child fields when their parents are unchecked and ensures the correct field values are set in the submit handler.