### PR TITLE
Default View permissions

### DIFF
--- a/modules/redhen_connection/config/install/views.view.redhen_connection_list.yml
+++ b/modules/redhen_connection/config/install/views.view.redhen_connection_list.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_connection
+  module:
+    - user
 id: redhen_connection_list
 label: 'Redhen Connection List'
 module: views
@@ -21,8 +23,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer connection entities'
       cache:
         type: tag
         options: {  }
@@ -559,6 +562,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }
   page_1:
     display_plugin: page
@@ -574,4 +578,5 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }

--- a/modules/redhen_contact/config/install/views.view.redhen_contact_listing.yml
+++ b/modules/redhen_contact/config/install/views.view.redhen_contact_listing.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_contact
+  module:
+    - user
 _core:
   default_config_hash: 3syDjwSfWOe928QBGXSipdCx67bDwMzYxOWQt6mEUvQ
 id: redhen_contact_listing
@@ -23,8 +25,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer contact entities'
       cache:
         type: tag
         options: {  }
@@ -767,6 +770,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }
   page_1:
     display_plugin: page
@@ -783,4 +787,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }

--- a/modules/redhen_contact/redhen_contact.drush.inc
+++ b/modules/redhen_contact/redhen_contact.drush.inc
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Drush tools for the Redhen Contacts module.
+ */
+
+use Drupal\redhen_contact\Entity\Contact;
+
+/**
+ * Implements hook_drush_command().
+ */
+function redhen_contact_drush_command() {
+  $items = array();
+
+  // Deletes the temporary node table column created by save-moderation-states.
+  $items['redhen-contact-link-users'] = array(
+    'description' => "Link Users without Contacts to existing Contacts based on email address.
+
+Arguments:
+ check                                 The number of Users to check. (Default is 50).",
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'core' => array('8+'),
+  );
+
+  return $items;
+}
+
+/**
+ * Implements drush_hook_COMMAND().
+ *
+ * Search for users without Redhen Contacts and attempt to connect them to
+ * existing Contacts based on email address.
+ */
+function drush_redhen_contact_link_users($check = 50) {
+  $query = \Drupal::database()->select('users_field_data', 'u');
+  $query->leftJoin('redhen_contact', 'rc', 'rc.uid = u.uid');
+  $query->fields('u', ['uid', 'mail']);
+  $query->isNull('rc.uid');
+  $query->range(0, $check);
+  $results = $query->execute()->fetchAllAssoc('uid');
+  $log = [];
+  foreach ($results as $orphan) {
+    $contacts = Contact::loadByMail($orphan->mail);
+    if ($contacts) {
+      foreach ($contacts as $contact) {
+        if (!$contact->getUserId()) {
+          // We have a match!
+          $contact->setUserId($orphan->uid);
+          $contact->save();
+          $log[$orphan->uid] = $contact->id();
+          continue 2;
+        }
+      }
+    }
+  }
+  if (empty($log) && count($results) == $check) {
+    drush_print("No User/Contact connections were created from " . count($results) . " Users found without Contacts. You may want to re-run this function with a higher limit.");
+  }
+  else {
+    drush_print(count($log) . " User/Contact connections created from " . count($results) . " Users found without Contacts.");
+  }
+}

--- a/modules/redhen_contact/redhen_contact.module
+++ b/modules/redhen_contact/redhen_contact.module
@@ -516,7 +516,9 @@ function _redhen_contact_user_submission_apply($form, $form_state, $form_display
     $contact->isNew()) {
     foreach ($value_state->getValues()['form_display_' . $contact->getType()]
              as $field => $value) {
-      $contact->set($field, $value);
+      if ($contact->hasField($field)) {
+        $contact->set($field, $value);
+      }
     }
   }
 
@@ -558,7 +560,7 @@ function redhen_contact_user_registration_form_state(array $form, FormStateInter
     }
 
     // Skip any empty fields.
-    if (!redhen_contact_form_field_has_value($contact_fields[$key], $value)) {
+    if (!isset($contact_fields[$key]) || !redhen_contact_form_field_has_value($contact_fields[$key], $value)) {
       continue;
     }
 

--- a/modules/redhen_org/config/install/views.view.redhen_organization_list.yml
+++ b/modules/redhen_org/config/install/views.view.redhen_organization_list.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_org
+  module:
+    - user
 id: redhen_organization_list
 label: 'Redhen Organization List'
 module: views
@@ -21,8 +23,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer org entities'
       cache:
         type: tag
         options: {  }
@@ -532,6 +535,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }
   page_1:
     display_plugin: page
@@ -548,4 +552,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }


### PR DESCRIPTION
Require “administer [contact|org|connection] entities” permission to view `/redhen/[contact|org|connection]` Views by default.

This prevents exposing potentially sensitive CRM data by accident if end-users don't add permissions to these Views.