### PR TITLE
Default View permissions

### DIFF
--- a/modules/redhen_connection/config/install/views.view.redhen_connection_list.yml
+++ b/modules/redhen_connection/config/install/views.view.redhen_connection_list.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_connection
+  module:
+    - user
 id: redhen_connection_list
 label: 'Redhen Connection List'
 module: views
@@ -21,8 +23,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer org entities'
       cache:
         type: tag
         options: {  }
@@ -559,6 +562,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions        
       tags: {  }
   page_1:
     display_plugin: page
@@ -574,4 +578,5 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }

--- a/modules/redhen_contact/config/install/views.view.redhen_contact_listing.yml
+++ b/modules/redhen_contact/config/install/views.view.redhen_contact_listing.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_contact
+  module:
+    - user
 _core:
   default_config_hash: 3syDjwSfWOe928QBGXSipdCx67bDwMzYxOWQt6mEUvQ
 id: redhen_contact_listing
@@ -23,8 +25,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer org entities'
       cache:
         type: tag
         options: {  }
@@ -767,6 +770,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions        
       tags: {  }
   page_1:
     display_plugin: page
@@ -783,4 +787,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }

--- a/modules/redhen_org/config/install/views.view.redhen_organization_list.yml
+++ b/modules/redhen_org/config/install/views.view.redhen_organization_list.yml
@@ -5,6 +5,8 @@ dependencies:
   enforced:
     module:
       - redhen_org
+  module:
+    - user
 id: redhen_organization_list
 label: 'Redhen Organization List'
 module: views
@@ -21,8 +23,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'administer org entities'
       cache:
         type: tag
         options: {  }
@@ -532,6 +535,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }
   page_1:
     display_plugin: page
@@ -548,4 +552,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }


### PR DESCRIPTION
Require “administer [contact|org|connection] entities” permission to view `/redhen/[contact|org|connection]` Views by default.

This prevents exposing potentially sensitive CRM data by accident if end-users don't add permissions to these Views.